### PR TITLE
Added new button to call agent

### DIFF
--- a/app/src/main/java/org/linphone/ui/assistant/viewmodel/ThirdPartySipAccountLoginViewModel.kt
+++ b/app/src/main/java/org/linphone/ui/assistant/viewmodel/ThirdPartySipAccountLoginViewModel.kt
@@ -41,6 +41,7 @@ import org.linphone.network.RetrofitBuilder
 import org.linphone.ui.GenericViewModel
 import org.linphone.utils.AppUtils
 import org.linphone.utils.Event
+import org.linphone.utils.UserSession
 import java.util.Locale
 
 class ThirdPartySipAccountLoginViewModel
@@ -171,7 +172,16 @@ constructor() : GenericViewModel() {
                     val apiPassword = userDetails.password
                     val apiDomain = userDetails.authorized_sip_domain
 
-                    Log.i("$TAG Parsed username is [$apiUsername] and domain [$apiDomain]")
+                    UserSession.accountType = userDetails.account_type
+                    UserSession.supportNumber = userDetails.support_number
+                    UserSession.authorizedSipDomain = userDetails.authorized_sip_domain
+
+                    Log.i(
+                        "$TAG Parsed username is [$apiUsername] and domain [$apiDomain]" +
+                            "ACCOUNT TYPE ==== $UserSession.accountType " +
+                            "SUPPORT NUMBER == ${UserSession.supportNumber}" +
+                                "DOMAIN ===== ${UserSession.authorizedSipDomain}"
+                    )
 
                     newlyCreatedAuthInfo = Factory.instance().createAuthInfo(
                         apiUsername, "", apiPassword, null, null, apiDomain
@@ -189,6 +199,7 @@ constructor() : GenericViewModel() {
                     newlyCreatedAccount = core.createAccount(accountParams)
                     core.addListener(coreListener)
                     core.addAccount(newlyCreatedAccount)
+
                 } catch (e: Exception) {
                     accountLoginErrorEvent.postValue(Event("Login failed: ${e.localizedMessage}"))
                 }

--- a/app/src/main/java/org/linphone/utils/UserSession.kt
+++ b/app/src/main/java/org/linphone/utils/UserSession.kt
@@ -1,0 +1,9 @@
+package org.linphone.utils
+
+object UserSession {
+    var accountType: String? = null
+    var supportNumber: String? = null
+    var authorizedSipDomain: String? = null
+
+    fun isClient(): Boolean = accountType == "client"
+}

--- a/app/src/main/res/color/support_button_tint_color.xml
+++ b/app/src/main/res/color/support_button_tint_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/green_success_200_night" android:state_selected="true" />
+    <item android:color="?attr/color_grey_300" />
+</selector>

--- a/app/src/main/res/drawable/support_fill.xml
+++ b/app/src/main/res/drawable/support_fill.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#4e6074"
+        android:pathData="M12,1C6.48,1 2,5.48 2,11v2c0,1.1 0.9,2 2,2h1v-6H4c0-4.42 3.58-8 8-8s8,3.58 8,8h-1v6h1c1.1,0 2-0.9 2-2v-2c0-5.52 -4.48-10 -10-10zM6,17c0,1.1 0.9,2 2,2h1v-4H8c-1.1,0 -2,0.9 -2,2zM15,15v4h1c1.1,0 2-0.9 2-2s-0.9-2 -2-2h-1z" />
+</vector>

--- a/app/src/main/res/layout/call_actions_bottom_sheet.xml
+++ b/app/src/main/res/layout/call_actions_bottom_sheet.xml
@@ -20,6 +20,9 @@
         <variable
             name="callsViewModel"
             type="org.linphone.ui.call.viewmodel.CallsViewModel" />
+        <variable
+            name="supportClickListener"
+            type="View.OnClickListener" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -209,6 +212,24 @@
             app:layout_constraintStart_toStartOf="@id/calls_list"
             app:layout_constraintEnd_toEndOf="@id/calls_list" />
 
+        <ImageView
+            android:id="@+id/support_call"
+            android:onClick="@{() -> viewModel.supportCall()}"
+            android:enabled="@{viewModel.isRecordingEnabled &amp;&amp; !viewModel.isPaused &amp;&amp; !viewModel.isPausedByRemote &amp;&amp; !viewModel.isSupportCallActive}"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/call_button_size"
+            android:layout_marginTop="@dimen/call_extra_button_top_margin"
+            android:padding="@dimen/call_button_icon_padding"
+            android:background="@drawable/in_call_button_background_red"
+            android:src="@drawable/support_fill"
+            android:contentDescription="@string/call_action_support_call"
+            android:selected="@{viewModel.isSupportCallActive}"
+            app:tint="@color/in_call_button_tint_color"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintTop_toBottomOf="@id/layout_label"
+            app:layout_constraintStart_toStartOf="@id/layout"
+            app:layout_constraintEnd_toEndOf="@id/layout" />
+
         <androidx.appcompat.widget.AppCompatTextView
             style="@style/in_call_extra_action_label_style"
             android:id="@+id/transfer_label"
@@ -293,6 +314,19 @@
             app:layout_constraintTop_toBottomOf="@id/record_call"
             app:layout_constraintStart_toStartOf="@id/calls_list_label"
             app:layout_constraintEnd_toEndOf="@id/calls_list_label" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            style="@style/in_call_extra_action_label_style"
+            android:id="@+id/record_support_label"
+            android:onClick="@{() -> viewModel.toggleRecording()}"
+            android:enabled="@{viewModel.isRecordingEnabled &amp;&amp; !viewModel.isPaused &amp;&amp; !viewModel.isPausedByRemote}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:paddingBottom="15dp"
+            android:text="@string/call_action_support_call"
+            app:layout_constraintTop_toBottomOf="@id/support_call"
+            app:layout_constraintStart_toStartOf="@id/layout_label"
+            app:layout_constraintEnd_toEndOf="@id/layout_label" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -650,6 +650,7 @@
     <string name="call_action_pause_call">Mettre en pause</string>
     <string name="call_action_resume_call">Reprendre</string>
     <string name="call_action_record_call">Enregistrer</string>
+    <string name="call_action_support_call">soutien</string>
     <string name="call_action_hang_up">Raccrocher</string>
     <string name="call_action_change_layout">Disposition</string>
     <string name="call_state_outgoing_progress">En cours</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <!ENTITY appName "ThirdEar">
 ]>
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" translatable="false">&appName;</string>
 
     <!-- Not translatable strings -->
@@ -691,6 +691,7 @@
     <string name="call_action_pause_call">Pause</string>
     <string name="call_action_resume_call">Resume</string>
     <string name="call_action_record_call">Record</string>
+    <string name="call_action_support_call">Support</string>
     <string name="call_action_hang_up">Hang up</string>
     <string name="call_action_change_layout">Layout</string>
     <string name="call_state_outgoing_progress">In progress</string>


### PR DESCRIPTION
🎯 Objective
To allow a user with the account type client to:
Place the current SIP call on hold.


Automatically initiate a support call using another SIP invite.


Disable the support button after it is used.


Visually reflect the support call state on the UI.


📱 UX Behavior
Button State:


Enabled when a call is active, not paused, not recording-disabled.


Disabled after initiating a support call.


Visual Feedback:


Tint/color of the vector icon changes, similar to the call recording button.
✅ Client Requirements Covered
✔ ️ Support call only available for client account type.


✔️ Current call is held before the support call.


✔ ️ Support number called using a valid SIP URI.


✔ ️ Button gets disabled post support call.


✔ ️ UI feedback and interaction consistent with the rest of the app.
![image](https://github.com/user-attachments/assets/a5521336-dea6-470f-9ff9-01906c051da5)
